### PR TITLE
Fix: Do not join paths for `/deposit` and `/withdraw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.1] - 2018-02-19
+### Fixed
+- Do not join paths when using `/deposit` and `/withdraw`.
+
 ## [0.6.0] - 2018-09-27
 ### Added
 - Add `StellarClient::Client.deposit`

--- a/lib/stellar_client/requests/deposit_request.rb
+++ b/lib/stellar_client/requests/deposit_request.rb
@@ -21,7 +21,7 @@ module StellarClient
     private
 
     def path
-      [Addressable::URI.parse(host).path, "/deposit"].join
+      "/deposit"
     end
 
     def params

--- a/lib/stellar_client/requests/withdraw_request.rb
+++ b/lib/stellar_client/requests/withdraw_request.rb
@@ -15,7 +15,7 @@ module StellarClient
     private
 
     def path
-      [Addressable::URI.parse(host).path, "/withdraw"].join
+      "/withdraw"
     end
 
     def params

--- a/lib/stellar_client/version.rb
+++ b/lib/stellar_client/version.rb
@@ -1,3 +1,3 @@
 module StellarClient
-  VERSION = "0.6.0".freeze
+  VERSION = "0.6.1".freeze
 end

--- a/stellar_client.gemspec
+++ b/stellar_client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gem_config", "~> 0.3.1"
   spec.add_dependency "typhoeus", "~> 1.1"
   spec.add_dependency "virtus", "~> 1.0"
-  spec.add_dependency "api_client_base", "~> 1.4"
+  spec.add_dependency "api_client_base", ">= 1.4.1"
   spec.add_dependency "activesupport", ">= 3.0.0"
   spec.add_dependency "addressable"
   spec.add_dependency "tomlrb", "~> 1.0"


### PR DESCRIPTION
`api_client_base` was fixed to allow hosts that have paths (they will no longer be completely overwritten).